### PR TITLE
Fix downloading bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Others
+.idea/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ It cannot download:
 pip install requests
 pip install lxml
 pip install beautifulsoup4
+pip install urllib3
 ```
 3. Download the whole package (but don't forget to unpack it) or at least these files:
 - 'fimfiction_stories_downloader.py',
@@ -41,11 +42,12 @@ pip install beautifulsoup4
 ```
 sudo apt install python-3 pip
 ```
-2. Then provide the root password and enter:
+2. Then provide the root password and either run 'python_libraries_installer.sh' or install the libraries manually by running these commands:
 ```
 pip3 install requests
 pip3 install lxml
 pip3 install beautifulsoup4
+pip3 install urllib3
 ```
 3. Download the 'fimfiction_stories_downloader.py'
 4. Now find out the address of the file by checking its properties and enter it into the terminal afer 'python3" to start the program. It should looks similar to this one:

--- a/python_libraries_installer.sh
+++ b/python_libraries_installer.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+pip3 install requests
+pip3 install lxml
+pip3 install beautifulsoup4
+pip3 install urllib3


### PR DESCRIPTION
While testing the program on Manjaro, I encountered a few bugs which this commit should fix:
1. While downloading from multiple pages from a library URL without an '&', the program would just iterate over the same page multiple times and append a second 'page' query to the URL, rather than modifying the existing one.
2. The view mode wouldn't get properly set on certain pages, causing only 10 stories at most to be downloaded.
3. On some pages, the links use a 'story_name' class rather than 'story_link', causing nothing to be downloaded. I don't know why it's sometimes like this, but I could reliably replicate this behavior by downloading the page with wget or curl.
4. Some filenames with special characters didn't get decoded properly.